### PR TITLE
Renamed header to Header after git didn't recognize case change.

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,0 +1,42 @@
+/**
+ * Learn React Native
+ * Header Component
+ * Written by Sam Reaves
+ * February 18, 2017
+ * https://github.com/samreaves/learn-react-native
+ */
+
+import React from 'react';
+import { Text, View } from 'react-native';
+
+/* Create Header Component */
+const Header = (props) => {
+
+  const { textStyles, viewStyles } = styles;
+
+  return (
+    <View style={viewStyles}>
+      <Text style={textStyles}>{ props.title }</Text>
+    </View>
+  );
+};
+
+const styles = {
+  viewStyles: {
+    alignItems: 'center',
+    backgroundColor: '#F8F8F8',
+    elevation: 2,
+    height: 60,
+    justifyContent: 'center',
+    paddingTop: 15,
+    position: 'relative',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 }
+  },
+  textStyles: {
+    fontSize: 20
+  }
+};
+
+/* Export Header Component */
+export default Header;


### PR DESCRIPTION
Renamed header to Header and git recognizes it this time because I turned on case-sensitivity. That's a really dumb default, git.